### PR TITLE
Keep pages to 1 when list is empty in UnscalablePaginatedList

### DIFF
--- a/src/components/PaginatedList.tsx
+++ b/src/components/PaginatedList.tsx
@@ -28,7 +28,7 @@ export const UnscalablePaginatedList = <T,>({
       <Table data={tableData} />
       <Pagination
         page={page}
-        pages={Math.ceil((data.length as number) / pageSize)}
+        pages={Math.max(1, Math.ceil((data.length as number) / pageSize))}
         onPageChange={setPage}
       />
     </div>


### PR DESCRIPTION
This fixes an infinite loop error caused by Pagination (L26-27)