### PR TITLE
Apply StyledModal's styles to Confirmation modals

### DIFF
--- a/src/components/SelectUsers.tsx
+++ b/src/components/SelectUsers.tsx
@@ -8,6 +8,7 @@ import {
   birthdayValidation,
   FormInputError,
 } from 'components'
+import modalStyles from 'components/StyledModal/StyledModal.module.scss'
 import { useDebouncedState } from 'hooks/debouncedState'
 import { useReadUnknownAndFullUsers } from 'hooks/readUnknownAndFullUsers'
 import { forwardRef, InputHTMLAttributes } from 'react'
@@ -284,19 +285,23 @@ const useReadFullUser = () => {
         confirmAlert({
           customUI: ({ title, message, onClose }) => {
             return (
-              <div>
-                <header>{title}</header>
-                <div>{message}</div>
-                <BirthdayForm
-                  onSubmit={birthday => {
-                    resolve(birthday)
-                    onClose()
-                  }}
-                  onCancel={() => {
-                    resolve('')
-                    onClose()
-                  }}
-                />
+              <div className={modalStyles.modal}>
+                <div className={modalStyles.content}>
+                  <header className={modalStyles.modalTitleBox}>{title}</header>
+                  <div className={modalStyles.modalFormBox}>
+                    <div className={modalStyles.infoBox}>{message}</div>
+                    <BirthdayForm
+                      onSubmit={birthday => {
+                        resolve(birthday)
+                        onClose()
+                      }}
+                      onCancel={() => {
+                        resolve('')
+                        onClose()
+                      }}
+                    />
+                  </div>
+                </div>
               </div>
             )
           },

--- a/src/components/StyledModal/StyledModal.module.scss
+++ b/src/components/StyledModal/StyledModal.module.scss
@@ -3,9 +3,12 @@
 .modal {
   background-color: white;
   width: 1000px;
+  max-width: 90%;
   position: fixed;
   top: 40px;
-  left: calc(50% - 400px);
+  left: 50%;
+  transform: translate(-50%, 0);
+  margin: 0 auto;
   display: flex;
   box-shadow: 0px 0px 18px 0px rgba($color: #000000, $alpha: 0.75);
   max-height: calc(100vh - 40px);

--- a/src/hooks/removeEvent.tsx
+++ b/src/hooks/removeEvent.tsx
@@ -1,4 +1,6 @@
 import { api } from 'app/services/bis'
+import { Actions, Button } from 'components'
+import modalStyles from 'components/StyledModal/StyledModal.module.scss'
 import {
   useShowApiErrorMessage,
   useShowMessage,
@@ -19,27 +21,33 @@ export const useRemoveEvent = () => {
     const isConfirmed = await new Promise((resolve, reject) => {
       confirmAlert({
         customUI: ({ title, message, onClose }) => (
-          <div>
-            <header>{title}</header>
-            <div>{message}</div>
-            <nav>
-              <button
-                onClick={() => {
-                  resolve(false)
-                  onClose()
-                }}
-              >
-                Zruš
-              </button>
-              <button
-                onClick={() => {
-                  resolve(true)
-                  onClose()
-                }}
-              >
-                Pokračuj
-              </button>
-            </nav>
+          <div className={modalStyles.modal}>
+            <div className={modalStyles.content}>
+              <header className={modalStyles.modalTitleBox}>{title}</header>
+              <div className={modalStyles.modalFormBox}>
+                <div className={modalStyles.infoBox}>{message}</div>
+                <Actions>
+                  <Button
+                    light
+                    onClick={() => {
+                      resolve(false)
+                      onClose()
+                    }}
+                  >
+                    Zruš
+                  </Button>
+                  <Button
+                    danger
+                    onClick={() => {
+                      resolve(true)
+                      onClose()
+                    }}
+                  >
+                    Pokračuj
+                  </Button>
+                </Actions>
+              </div>
+            </div>
           </div>
         ),
         title: `Mažeš akci ${event.name}`,

--- a/src/org/components/EventForm/steps/registration/NewApplicationModal.tsx
+++ b/src/org/components/EventForm/steps/registration/NewApplicationModal.tsx
@@ -245,7 +245,7 @@ export const NewApplicationModal: FC<INewApplicationModalProps> = ({
                   <Label htmlFor="close_person_phone">Telefon</Label>
                   <FormInputError>
                     <input
-                      type="phone"
+                      type="tel"
                       id="close_person_phone"
                       {...register('close_person.phone')}
                     />


### PR DESCRIPTION
In particular, apply styles to
- modal that confirms event removal
- modal that asks for birthday of unknown users

It's a bit non-dry, and perhaps we could reuse react-modal and get rid of the react-confirm-alert library (TODO)