### PR TITLE
Clear contacts and number of participants when saving full participants

### DIFF
--- a/cypress/e2e/closeEvent.cy.ts
+++ b/cypress/e2e/closeEvent.cy.ts
@@ -137,6 +137,8 @@ describe('Close event - evidence and participants', () => {
                 newUserExample.id,
               ],
               contacts: [],
+              number_of_participants: null,
+              number_of_participants_under_26: null,
             },
           })
       })

--- a/src/org/components/EventForm/steps/registration/AddParticipantModal.tsx
+++ b/src/org/components/EventForm/steps/registration/AddParticipantModal.tsx
@@ -192,6 +192,9 @@ export const AddParticipantModal: FC<INewApplicationModalProps> = ({
       event: {
         record: {
           participants: newParticipants,
+          contacts: [],
+          number_of_participants: null,
+          number_of_participants_under_26: null,
         },
       },
     })

--- a/src/org/components/EventForm/steps/registration/Participants.tsx
+++ b/src/org/components/EventForm/steps/registration/Participants.tsx
@@ -82,6 +82,8 @@ export const Participants: FC<{
         record: {
           participants: newParticipants,
           contacts: [],
+          number_of_participants: null,
+          number_of_participants_under_26: null,
         },
       },
     }).unwrap()


### PR DESCRIPTION
We want to save only one of the options, therefore they should overwrite each other