### PR TITLE
Show warning when function has unused arguments

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+# node_modules are ignored by default
+# https://eslint.org/docs/latest/user-guide/configuring/ignoring-code#the-eslintignore-file
+
+/build

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,3 +7,8 @@ rules:
   'prettier/prettier': warn
   'no-console': warn
   'import/no-default-export': error
+  # check for unused arguments (overriding extended rule)
+  '@typescript-eslint/no-unused-vars':
+    - warn
+    - args: after-used
+      ignoreRestSiblings: false

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 # cypress output
-
 cypress/videos

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress'
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents(/*on, config*/) {
       // implement node event listeners here
     },
     baseUrl: 'http://localhost:3000',

--- a/cypress/e2e/forbidCreateEvent.cy.ts
+++ b/cypress/e2e/forbidCreateEvent.cy.ts
@@ -1,32 +1,3 @@
-import type { Location } from '../../src/app/services/bisTypes'
-
-const searchUsers = new Array(47).fill('').map((val, i) => ({
-  _search_id: String(i),
-  first_name: `FirstName${i}`,
-  last_name: `LastName${i}`,
-  nickname: `Nickname${i}`,
-  display_name: `Displayname${i}`,
-}))
-
-const locations: Location[] = new Array(35)
-  .fill('')
-  .map((val, i) => ({
-    id: i,
-    name: `Location ${i}`,
-    gps_location: {
-      type: 'Point',
-      coordinates: [12 + Math.random() * 7, 49 + Math.random() * 2],
-    },
-  }))
-  .flat() as Location[]
-
-// go to next step
-const next = () =>
-  cy.get('button[aria-label="Go to next step"]').should('be.visible').click()
-
-const submit = () =>
-  cy.get('[type=submit]:contains(Uložit)').first().should('be.visible').click()
-
 describe('create event', () => {
   // stub api endpoints before each request
   beforeEach(() => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -76,7 +76,7 @@ Cypress.Commands.add(
 )
 
 // providing id is not implemented
-Cypress.Commands.add('interceptFullEvent', (id?: number) => {
+Cypress.Commands.add('interceptFullEvent', () => {
   cy.intercept(
     { method: 'GET', pathname: '/api/frontend/events/1000/' },
     { fixture: 'event' },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,14 +1,14 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { App } from './App'
 import { store } from './app/store'
 
 test('renders learn react link', () => {
-  const { getByText } = render(
+  render(
     <Provider store={store}>
       <App />
     </Provider>,
   )
 
-  expect(getByText(/learn/i)).toBeInTheDocument()
+  expect(screen.getByText(/learn/i)).toBeInTheDocument()
 })

--- a/src/app/services/bis.ts
+++ b/src/app/services/bis.ts
@@ -506,7 +506,7 @@ export const api = createApi({
           search: queryArg.search,
         },
       }),
-      providesTags: (results, error, { userId, id, page }) =>
+      providesTags: results =>
         results?.results
           ? [
               ...results.results.map(event => ({

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -41,7 +41,7 @@ listenerMiddleware.startListening({
     api.endpoints.logout.matchFulfilled,
     api.endpoints.logout.matchRejected,
   ),
-  effect: async (action, listenerApi) => {
+  effect: async () => {
     await resetStore()
   },
 })

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -15,7 +15,7 @@ export const UncontrolledImageUpload = forwardRef<
     onChange: (e: ChangeEvent<HTMLInputElement>) => void
     onBlur: any
   }
->(({ name, value, onChange, onBlur }, ref) => {
+>(({ value, onChange, ...rest }, ref) => {
   const [internalState, setInternalState] = useState<string>('')
 
   const actualValue = value ?? internalState
@@ -33,8 +33,8 @@ export const UncontrolledImageUpload = forwardRef<
         style={{ display: 'none' }}
         type="file"
         accept="image/*"
-        name={name}
         onChange={handleChange}
+        {...rest}
       />
       {actualValue ? (
         <div className={styles.imageWrapper}>

--- a/src/components/ImportExcelButton/ImportExcelButton.tsx
+++ b/src/components/ImportExcelButton/ImportExcelButton.tsx
@@ -17,7 +17,6 @@ export const ImportExcelButton = <T extends {}>({
   keyMap,
   children,
   onUpload,
-  ...props
 }: ImportExcelButtonProps<T>) => {
   const handleUpload: ChangeEventHandler<HTMLInputElement> = async e => {
     if (e.target.files && e.target.files.length > 0) {

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -64,7 +64,7 @@ const MapEvents = ({
       const ll = map.mouseEventToLatLng(e.originalEvent)
       if (onClick) onClick(ll)
     },
-    moveend(e) {
+    moveend() {
       onMoveEnd?.(getClearBounds(map))
     },
   })
@@ -135,7 +135,6 @@ export interface MapProps {
   value?: L.LatLngTuple
   onChange: (location: L.LatLngTuple) => void
   onSelect: (id: number) => void
-  onDeselect: () => void
   onChangeBounds?: (bounds: ClearBounds) => void
   onError?: (error: Error) => void
   isLoading: boolean
@@ -149,7 +148,6 @@ export const Map = ({
   value,
   onChange,
   onSelect,
-  onDeselect,
   onChangeBounds,
   isLoading,
   editMode,
@@ -196,9 +194,9 @@ export const Map = ({
               <small>Načítáme lokality</small>
             </div>
           ) : (
-            /* In theory, this could be replaced by MapyCzMap 1-1
-          but that component is still unfinished and buggy
-          we don't recommend it */
+            /**
+             * This can be replaced byt OSMSearch if needed
+             */
             <MapyCzSearch
               onSelect={handleSearch}
               onError={handleError}

--- a/src/components/MapyCzMap/MapyCzMap.tsx
+++ b/src/components/MapyCzMap/MapyCzMap.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import { MapyCzSearch } from 'components'
 import type { MapProps } from 'components/Map/Map'
 import { useOnScreen } from 'hooks/onScreen'
@@ -21,7 +23,6 @@ export const MapyCzMap = ({
   value,
   onChange,
   onSelect,
-  onDeselect,
   onChangeBounds,
   onError,
 }: MapProps) => {

--- a/src/components/MapyCzSearch/MapyCzSearch.tsx
+++ b/src/components/MapyCzSearch/MapyCzSearch.tsx
@@ -4,11 +4,11 @@ import { useEffect, useRef } from 'react'
 export const MapyCzSearch = ({
   onSelect,
   className,
-  onError,
 }: {
   onSelect: (coords: [number, number], name: string) => void
   className?: string
-  onError?: (e: Error) => void
+  // unused prop to ensure that the component has the same interface as OSMSearch
+  onError: (error: Error) => void
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [SMap] = useSMap()

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -26,6 +26,7 @@ export const NumberInput = forwardRef<
         <FaMinus />
       </div>
       <input
+        ref={ref}
         className={styles.input}
         type="number"
         value={value ?? undefined}

--- a/src/components/OSMSearch/OSMSearch.tsx
+++ b/src/components/OSMSearch/OSMSearch.tsx
@@ -20,7 +20,7 @@ export const OSMSearch = ({
   const [searchOSMLocation, { isLoading: isSearching }] =
     api.endpoints.searchLocationOSM.useLazyQuery()
 
-  const handleSearchFormSubmit = handleSubmit(async (data, e) => {
+  const handleSearchFormSubmit = handleSubmit(async data => {
     if (data.query.length > 2) {
       try {
         const foundLocations = await searchOSMLocation(data.query).unwrap()

--- a/src/components/SelectLocation/SelectLocation.tsx
+++ b/src/components/SelectLocation/SelectLocation.tsx
@@ -18,7 +18,7 @@ import {
 import { LatLngTuple } from 'leaflet'
 import { cloneDeep } from 'lodash'
 import merge from 'lodash/merge'
-import { FocusEvent, forwardRef, useEffect, useMemo, useState } from 'react'
+import { forwardRef, useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm, UseFormReturn } from 'react-hook-form'
 import { AiOutlineEdit } from 'react-icons/ai'
 import { FiCheckCircle } from 'react-icons/fi'
@@ -216,7 +216,6 @@ export const SelectLocation = forwardRef<
               }}
               onSelect={handleSelect}
               onChangeBounds={bounds => setBounds(bounds)}
-              onDeselect={() => {}}
               isLoading={isLoading}
               editMode={isEditing}
             />{' '}
@@ -300,7 +299,7 @@ const CreateLocation = ({
     { required },
   )
 
-  const handleGPSBlur = (e: FocusEvent<HTMLInputElement, Element>) => {
+  const handleGPSBlur = () => {
     const rawCoordinates = methods.getValues('gps_location.coordinates')
     const areCoordinatesNumeric = rawCoordinates.every(
       a => !isNaN(parseInt(a as unknown as string)),
@@ -351,7 +350,7 @@ const CreateLocation = ({
               form={formId}
               {...registerLatitude}
               onBlur={e => {
-                handleGPSBlur(e)
+                handleGPSBlur()
                 blurLatitude(e)
               }}
               className={styles.GPS}
@@ -365,7 +364,7 @@ const CreateLocation = ({
               form={formId}
               {...registerLongitude}
               onBlur={e => {
-                handleGPSBlur(e)
+                handleGPSBlur()
                 blurLongitude(e)
               }}
               className={styles.GPS}

--- a/src/components/SelectObject.tsx
+++ b/src/components/SelectObject.tsx
@@ -84,7 +84,7 @@ const SelectObjectInner = <T,>(
       getOptionLabel={getLabel}
       getOptionValue={getValue}
       className={`${className} customInput ${styles.selectObject}`}
-      noOptionsMessage={prop => {
+      noOptionsMessage={() => {
         if (!searchQuery || searchQuery.length < 3)
           return <div>Zadej alespoň 2 znaky</div>
         return <div>Nenalezeno</div>

--- a/src/components/SelectUsers.tsx
+++ b/src/components/SelectUsers.tsx
@@ -284,7 +284,7 @@ const useReadFullUser = () => {
   const [readUserByBirthday] = api.endpoints.readUserByBirthdate.useLazyQuery()
   return async (user: UserSearch): Promise<User> => {
     try {
-      const birthday = (await new Promise((resolve, reject) => {
+      const birthday = (await new Promise(resolve => {
         confirmAlert({
           customUI: ({ title, message, onClose }) => {
             return (

--- a/src/components/Steps/Steps.tsx
+++ b/src/components/Steps/Steps.tsx
@@ -108,7 +108,7 @@ export const Steps = <T extends Record<string, any>>({
         )}
         {onSubmit &&
           actions &&
-          actions.map(({ props, name }, i) => (
+          actions.map(({ props, name }) => (
             <Button
               key={name}
               primary

--- a/src/components/UserForm/UserForm.tsx
+++ b/src/components/UserForm/UserForm.tsx
@@ -24,10 +24,12 @@ import {
   Label,
   Loading,
 } from 'components'
+import * as translations from 'config/static/translations'
 import { useShowMessage } from 'features/systemMessage/useSystemMessage'
 import { merge, omit, startsWith } from 'lodash'
 import { useEffect } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { validationErrors2Message } from 'utils/validationErrors'
 import { requiredSelect } from 'utils/validationMessages'
 import * as yup from 'yup'
 
@@ -232,6 +234,11 @@ export const UserForm = ({
       showMessage({
         type: 'error',
         message: 'Opravte, prosím, chyby ve validaci',
+        detail: validationErrors2Message(
+          merge({}, ...Object.values(errors)),
+          translations.user,
+          translations.generic,
+        ),
       })
     },
   )

--- a/src/features/systemMessage/useSystemMessage.ts
+++ b/src/features/systemMessage/useSystemMessage.ts
@@ -53,7 +53,7 @@ export const useShowApiErrorMessage = (
   message = 'Něco se nepovedlo',
   fieldTranslations = combinedFieldTranslations,
   genericTranslations = translations.generic,
-  limit = Infinity,
+  // limit = Infinity,
 ) => {
   const showMessage = useShowMessage()
   useEffect(() => {
@@ -64,7 +64,7 @@ export const useShowApiErrorMessage = (
         error,
         fieldTranslations,
         genericTranslations,
-        limit,
+        // limit,
       )
     } else {
       detail += `${error?.code ?? ''} ${error?.name ?? ''}\n${
@@ -77,12 +77,5 @@ export const useShowApiErrorMessage = (
         detail,
         type: 'error',
       })
-  }, [
-    error,
-    fieldTranslations,
-    genericTranslations,
-    limit,
-    message,
-    showMessage,
-  ])
+  }, [error, fieldTranslations, genericTranslations, message, showMessage])
 }

--- a/src/hooks/persistForm.ts
+++ b/src/hooks/persistForm.ts
@@ -50,7 +50,7 @@ export const usePersistForm = (
   for (const watch of watches) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
-      const subscription = watch((data, asdf) => {
+      const subscription = watch(data => {
         debouncedDispatch(
           actions.saveForm({
             id,

--- a/src/hooks/rejectApplication.tsx
+++ b/src/hooks/rejectApplication.tsx
@@ -22,7 +22,7 @@ export const useRejectApplication = () => {
     application: { id: number; first_name: string; last_name: string }
   }) => {
     // replace with custom ui
-    const isConfirmed = await new Promise((resolve, reject) => {
+    const isConfirmed = await new Promise(resolve => {
       confirmAlert({
         customUI: ({ title, message, onClose }) => (
           <div className={modalStyles.modal}>

--- a/src/hooks/removeEvent.tsx
+++ b/src/hooks/removeEvent.tsx
@@ -18,7 +18,7 @@ export const useRemoveEvent = () => {
 
   const removeEventWithModal = async (event: { id: number; name: string }) => {
     // replace with custom ui
-    const isConfirmed = await new Promise((resolve, reject) => {
+    const isConfirmed = await new Promise(resolve => {
       confirmAlert({
         customUI: ({ title, message, onClose }) => (
           <div className={modalStyles.modal}>

--- a/src/hooks/removeOpportunity.tsx
+++ b/src/hooks/removeOpportunity.tsx
@@ -23,7 +23,7 @@ export const useRemoveOpportunity = () => {
     name: string
   }) => {
     // replace with custom ui
-    const isConfirmed = await new Promise((resolve, reject) => {
+    const isConfirmed = await new Promise(resolve => {
       confirmAlert({
         customUI: ({ title, message, onClose }) => (
           // this modal component is copy-pasted from similar useRemoveEvent hook

--- a/src/hooks/useCancelEvent.tsx
+++ b/src/hooks/useCancelEvent.tsx
@@ -18,7 +18,7 @@ export const useCancelEvent = () => {
 
   const cancelEventWithModal = async (event: { id: number; name: string }) => {
     // replace with custom ui
-    const isConfirmed = await new Promise((resolve, reject) => {
+    const isConfirmed = await new Promise(resolve => {
       confirmAlert({
         customUI: ({ title, message, onClose }) => (
           <div className={modalStyles.modal}>
@@ -77,7 +77,7 @@ export const useRestoreCanceledEvent = () => {
     name: string
   }) => {
     // replace with custom ui
-    const isConfirmed = await new Promise((resolve, reject) => {
+    const isConfirmed = await new Promise(resolve => {
       confirmAlert({
         customUI: ({ title, message, onClose }) => (
           <div className={modalStyles.modal}>

--- a/src/index.scss
+++ b/src/index.scss
@@ -47,4 +47,3 @@ code {
 
 @import 'styles/menu';
 @import 'styles/forms';
-

--- a/src/org/components/EventForm/EventForm.tsx
+++ b/src/org/components/EventForm/EventForm.tsx
@@ -277,7 +277,7 @@ export const EventForm: FC<{
   onCancel: () => void
   eventToEdit: boolean
   id: string
-}> = ({ onSubmit, onCancel, initialData, eventToEdit, id }) => {
+}> = ({ onSubmit, onCancel, initialData, id }) => {
   const savedData = usePersistentFormData('event', id) as
     | Partial<EventFormShape>
     | undefined

--- a/src/org/components/EventForm/steps/BasicInfoStep.tsx
+++ b/src/org/components/EventForm/steps/BasicInfoStep.tsx
@@ -119,7 +119,11 @@ export const BasicInfoStep = ({
                   required,
                 }}
                 render={({ field }) => (
-                  <NumberInput {...field} min={1} name="number_of_sub_events"></NumberInput>
+                  <NumberInput
+                    {...field}
+                    min={1}
+                    name="number_of_sub_events"
+                  ></NumberInput>
                 )}
               />
             </FormInputError>
@@ -163,7 +167,7 @@ export const BasicInfoStep = ({
                   name="administration_units"
                   rules={{ required }}
                   control={control}
-                  render={({ field: { onChange, value, name, ref } }) => (
+                  render={({ field: { onChange /*, value, name, ref */ } }) => (
                     <Select
                       isMulti
                       options={

--- a/src/org/components/EventForm/steps/IntendedForStep.tsx
+++ b/src/org/components/EventForm/steps/IntendedForStep.tsx
@@ -28,7 +28,7 @@ export const IntendedForStep = ({
 
   // unregister stuff
   useEffect(() => {
-    const subscription = watch((data, { name, type }) => {
+    const subscription = watch((data, { name }) => {
       if (
         name === 'intended_for' &&
         getIdBySlug(

--- a/src/org/components/EventForm/steps/OrganizerStep.tsx
+++ b/src/org/components/EventForm/steps/OrganizerStep.tsx
@@ -95,7 +95,7 @@ export const OrganizerStep = ({
    * Automatically fill organizer team
    */
   useEffect(() => {
-    const subscription = watch((data, { name, value }) => {
+    const subscription = watch((data, { name }) => {
       if (name === 'main_organizer' || name === 'other_organizers') {
         const mainOrganizer = get(data, 'main_organizer')
         const otherOrganizers = get(data, 'other_organizers', [])

--- a/src/org/components/EventForm/steps/PropagationStep.tsx
+++ b/src/org/components/EventForm/steps/PropagationStep.tsx
@@ -128,7 +128,7 @@ export const PropagationStep = ({
                     <InlineSection>
                       {[...diets.results]
                         .reverse() // fast hack to show meaty diet last
-                        .map(({ id, name, slug }) => (
+                        .map(({ id, name }) => (
                           <label key={id}>
                             <input
                               ref={field.ref}
@@ -184,7 +184,11 @@ export const PropagationStep = ({
                       required: isVolunteering && required,
                     }}
                     render={({ field }) => (
-                      <NumberInput {...field} min={0} name="propagation.working_days"></NumberInput>
+                      <NumberInput
+                        {...field}
+                        min={0}
+                        name="propagation.working_days"
+                      ></NumberInput>
                     )}
                   />
                 </FormInputError>

--- a/src/org/components/EventForm/steps/registration/Applications.tsx
+++ b/src/org/components/EventForm/steps/registration/Applications.tsx
@@ -52,8 +52,8 @@ export const Applications: FC<{
         : skipToken,
     )
 
-  const [deleteEventApplication] =
-    api.endpoints.deleteEventApplication.useMutation()
+  // const [deleteEventApplication] =
+  //   api.endpoints.deleteEventApplication.useMutation()
 
   const { data: applicationsData, isLoading: isReadApplicationsLoading } =
     api.endpoints.readEventApplications.useQuery({
@@ -294,9 +294,9 @@ export const Applications: FC<{
             currentApplication={currentApplication}
             eventName={eventName}
             eventId={eventId}
-            setCurrentApplicationId={setCurrentApplicationId}
-            setShowAddParticipantModal={setShowAddParticipantModal}
-            deleteEventApplication={deleteEventApplication}
+            // setCurrentApplicationId={setCurrentApplicationId}
+            // setShowAddParticipantModal={setShowAddParticipantModal}
+            // deleteEventApplication={deleteEventApplication}
             categories={membershipCategories?.results ?? []}
             administrationUnits={
               administrationUnits ? administrationUnits.results : []

--- a/src/org/components/EventForm/steps/registration/Participants.tsx
+++ b/src/org/components/EventForm/steps/registration/Participants.tsx
@@ -285,10 +285,8 @@ const UserModalForm = ({
 
 const RemoveParticipantConfirmDialog = ({
   onResolve,
-  onReject,
 }: {
   onResolve: (confirm: boolean) => void
-  onReject: () => void
 }) => (
   <Actions>
     <Button secondary onClick={() => onResolve(false)}>

--- a/src/org/components/EventForm/steps/registration/ShowApplicationModal.tsx
+++ b/src/org/components/EventForm/steps/registration/ShowApplicationModal.tsx
@@ -16,15 +16,15 @@ interface IShowApplicationModalProps {
   currentApplication?: EventApplication
   eventName: string
   eventId: number
-  setCurrentApplicationId?: (v: number) => void
-  setShowAddParticipantModal?: (v: boolean) => void
-  deleteEventApplication?: ({
-    applicationId,
-    eventId,
-  }: {
-    applicationId: number
-    eventId: number
-  }) => void
+  // setCurrentApplicationId?: (v: number) => void
+  // setShowAddParticipantModal?: (v: boolean) => void
+  // deleteEventApplication?: ({
+  //   applicationId,
+  //   eventId,
+  // }: {
+  //   applicationId: number
+  //   eventId: number
+  // }) => void
   userId?: string
   categories: MembershipCategory[]
   administrationUnits: AdministrationUnit[]
@@ -39,9 +39,9 @@ export const ShowApplicationModal: FC<IShowApplicationModalProps> = ({
   currentApplication: currentApplicationProp,
   eventName,
   eventId,
-  setCurrentApplicationId,
-  setShowAddParticipantModal,
-  deleteEventApplication,
+  // setCurrentApplicationId,
+  // setShowAddParticipantModal,
+  // deleteEventApplication,
   userId,
   categories,
   administrationUnits,

--- a/src/org/pages/CloseEvent/SimpleParticipants.tsx
+++ b/src/org/pages/CloseEvent/SimpleParticipants.tsx
@@ -39,7 +39,7 @@ export const SimpleParticipants = () => {
     promise: Promise<EventContact>
   }>()
 
-  const getModalData = (data: EventContact) => {
+  const getModalData = () => {
     let res = undefined
     let rej = undefined
 
@@ -62,7 +62,7 @@ export const SimpleParticipants = () => {
   const handleEdit = async (data: EventContact, i: number) => {
     setOpen(true)
     setDefaultValues(data)
-    const finalData = await getModalData(data)
+    const finalData = await getModalData()
     peopleFields.update(i, finalData)
   }
 

--- a/src/org/pages/UpdateEvent.tsx
+++ b/src/org/pages/UpdateEvent.tsx
@@ -98,7 +98,7 @@ export const UpdateEvent = () => {
 
     const newImages: { image: string; order: number }[] = []
     const imagesToPatch: { id: number; image?: string; order?: number }[] = []
-    imagesWithOrder.forEach((image, i, imagesWithOrder) => {
+    imagesWithOrder.forEach(image => {
       // save every new image
       // images without id are new
       if (!image.id) return newImages.push(image)

--- a/src/utils/apiErrors.ts
+++ b/src/utils/apiErrors.ts
@@ -11,7 +11,7 @@ export const apiErrors2Message = (
   error: FetchBaseQueryError,
   fieldNames: ModelTranslations = {},
   genericNames: GenericTranslations = {},
-  limit: number = Infinity,
+  // limit: number = Infinity,
 ): string => {
   let output = ''
   output += error.status


### PR DESCRIPTION
This was disabled by default by one of the extends

We overwrote @typescript-eslint/no-unused-vars rule's options
- `args: after-used` // was `none` before
- `ignoreRestSiblings: false`

We also fixed related warnings