### PR TITLE
Lazy load Quill and Leaflet with React.lazy

### DIFF
--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -126,7 +126,7 @@ export const DataView = <T extends Data>({
           !('id' in value && 'name' in value)
         )
           return (
-            <div>
+            <div key={key}>
               {createElement(
                 `h${depth + 2}`,
                 {},
@@ -142,7 +142,7 @@ export const DataView = <T extends Data>({
           )
 
         return (
-          <div>
+          <div key={key}>
             <span className={styles.inlineTitle}>
               {translateKey(key, translations, genericTranslations)}
             </span>

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -1,0 +1,1 @@
+export { Map } from './Map'

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,26 +1,28 @@
-import { forwardRef } from 'react'
+import React, { forwardRef, Suspense } from 'react'
 import { ControllerRenderProps } from 'react-hook-form'
-import ReactQuill from 'react-quill'
 import 'react-quill/dist/quill.core.css'
 import 'react-quill/dist/quill.snow.css'
 import { stripHtml } from 'utils/helpers'
 import styles from './RichTextEditor.module.scss'
+const ReactQuill = React.lazy(() => import('react-quill'))
 
 export const RichTextEditor = forwardRef<
   any,
   ControllerRenderProps<any, string> & { placeholder?: string }
 >((props, ref) => (
-  <ReactQuill
-    className={styles.wrapper}
-    theme="snow"
-    modules={{
-      toolbar: ['bold', { list: 'ordered' }, { list: 'bullet' }, 'link'],
-    }}
-    formats={['bold', 'list', 'bullet', 'link']}
-    {...props}
-    id={props.name}
-    ref={ref}
-  />
+  <Suspense>
+    <ReactQuill
+      className={styles.wrapper}
+      theme="snow"
+      modules={{
+        toolbar: ['bold', { list: 'ordered' }, { list: 'bullet' }, 'link'],
+      }}
+      formats={['bold', 'list', 'bullet', 'link']}
+      {...props}
+      id={props.name}
+      ref={ref}
+    />
+  </Suspense>
 ))
 
 // TODO rewrite to yay schema

--- a/src/components/SelectLocation/SelectLocation.tsx
+++ b/src/components/SelectLocation/SelectLocation.tsx
@@ -11,14 +11,19 @@ import {
   InfoBox,
   InlineSection,
   Label,
-  Map,
   MarkerType,
   SelectObject,
 } from 'components'
 import { LatLngTuple } from 'leaflet'
 import { cloneDeep } from 'lodash'
 import merge from 'lodash/merge'
-import { forwardRef, useEffect, useMemo, useState } from 'react'
+import React, {
+  forwardRef,
+  Suspense,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { FormProvider, useForm, UseFormReturn } from 'react-hook-form'
 import { AiOutlineEdit } from 'react-icons/ai'
 import { FiCheckCircle } from 'react-icons/fi'
@@ -26,6 +31,10 @@ import { Overwrite } from 'utility-types'
 import { required } from 'utils/validationMessages'
 import * as yup from 'yup'
 import styles from './SelectLocation.module.scss'
+const Map = React.lazy(async () => {
+  const { Map } = await import('components/Map')
+  return { default: Map }
+})
 
 export type NewLocation = Overwrite<
   Pick<Location, 'gps_location' | 'name' | 'address' | 'description'>,
@@ -204,21 +213,32 @@ export const SelectLocation = forwardRef<
       <div className={styles.mainContentContainerWrapper}>
         <div className={styles.mainContentContainer}>
           <div className={styles.mapColumn}>
-            <Map
-              className={styles.mapContainer}
-              markers={markers}
-              selection={selection}
-              value={isEditing ? newLocationCoordinates : undefined}
-              onChange={coordinates => {
-                if (isEditing) {
-                  setNewLocationCoordinates(coordinates)
-                }
-              }}
-              onSelect={handleSelect}
-              onChangeBounds={bounds => setBounds(bounds)}
-              isLoading={isLoading}
-              editMode={isEditing}
-            />{' '}
+            <Suspense
+              fallback={
+                <div
+                  className={classNames(
+                    styles.mapContainer,
+                    'leaflet-container',
+                  )}
+                />
+              }
+            >
+              <Map
+                className={styles.mapContainer}
+                markers={markers}
+                selection={selection}
+                value={isEditing ? newLocationCoordinates : undefined}
+                onChange={coordinates => {
+                  if (isEditing) {
+                    setNewLocationCoordinates(coordinates)
+                  }
+                }}
+                onSelect={handleSelect}
+                onChangeBounds={bounds => setBounds(bounds)}
+                isLoading={isLoading}
+                editMode={isEditing}
+              />
+            </Suspense>
             {isEditing ? (
               <Button
                 secondary

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,9 +32,9 @@ export { LazyImportExcelButton as ImportExcelButton } from './ImportExcelButton/
 export { InfoMessage } from './InfoMessage/InfoMessage'
 export { ListHeader } from './ListHeader/ListHeader'
 export { Loading } from './Loading/Loading'
-export { Map } from './Map/Map'
+// export { Map } from './Map/Map' // export separately to split bundle
 export type { ClearBounds, MarkerType } from './Map/Map'
-export { MapyCzMap } from './MapyCzMap/MapyCzMap'
+// export { MapyCzMap } from './MapyCzMap/MapyCzMap' // not used
 export { MapyCzSearch } from './MapyCzSearch/MapyCzSearch'
 export { NumberInput } from './NumberInput/NumberInput'
 export { OSMSearch } from './OSMSearch/OSMSearch'


### PR DESCRIPTION
These were the largest libraries left in the bundle. Now they load separately when they're actually needed. So the app can load faster at the beginning.

You can run `yarn analyze` to see how libraries contribute to bundles.