### PR TITLE
Redirect after login and logout

### DIFF
--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -7,22 +7,28 @@ export const useLogout = () => {
 
   const navigate = useNavigate()
 
-  const handleLogout = useCallback(async () => {
-    try {
-      // logout with endpoint
-      await logout().unwrap()
-      // remove auth token from local storage and state
-      // this is taken care of in src/app/store
-    } catch (e) {
-      // catch api errors, but continue to sign out anyways
-      // api failure should not block user's ability to sign out from frontend
-    } finally {
-      // go to homepage
-      navigate('/')
-      // and hard redirect to cleanup the state and whatnot
-      // globalThis.location.href = '/'
-    }
-  }, [logout, navigate])
+  const handleLogout = useCallback(
+    async (next?: string, reload?: boolean) => {
+      try {
+        // logout with endpoint
+        await logout().unwrap()
+        // remove auth token from local storage and state
+        // this is taken care of in src/app/store
+      } catch (e) {
+        // catch api errors, but continue to sign out anyways
+        // api failure should not block user's ability to sign out from frontend
+      } finally {
+        if (reload) {
+          // hard redirect to the next page
+          globalThis.location.href = next || '/'
+        } else {
+          // or go to the next page without hard redirect
+          navigate(next || '/')
+        }
+      }
+    },
+    [logout, navigate],
+  )
 
   return handleLogout
 }

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -154,7 +154,7 @@ export const Header = () => {
             <MenuDivider />
 
             <MenuItem className={styles.menuItemCustom}>
-              <button onClick={logout}>Odhlásit se</button>
+              <button onClick={() => logout()}>Odhlásit se</button>
             </MenuItem>
           </Menu>
         </nav>

--- a/src/layout/UnauthenticatedOutlet.tsx
+++ b/src/layout/UnauthenticatedOutlet.tsx
@@ -11,7 +11,15 @@ export const UnauthenticatedOutlet = () => {
   if (user) {
     const redirect =
       searchParams.get('next') ?? (isOrganizer(user) ? '/org' : '/')
-    return <Navigate to={redirect} replace />
+
+    const reload = searchParams.get('reload')
+
+    if (typeof reload === 'string') {
+      globalThis.location.href = redirect
+      return null
+    } else {
+      return <Navigate to={redirect} replace />
+    }
   } else if (isAuthenticated) {
     return <Loading>Připravujeme aplikaci</Loading>
   } else {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -46,58 +46,56 @@ export const Login = () => {
     return <Loading hideHeader>Přihlášení do panelu Brontosaurus...</Loading>
 
   return (
-    <>
-      <div className={styles.loginContainer}>
-        <div className={styles.formContainer}>
-          <header className={styles.title}>Přihlaste se ke svému účtu</header>
-          <p className={styles.subtitle}>
-            Zadejte své přihlašovací jméno a heslo <br />
-            pro přístup k aplikaci
-          </p>
-          {error && (
-            <div className={classNames(styles.error, styles.formElement)}>
-              {getErrorMessage(error)}
-            </div>
-          )}
-          <FormProvider {...formMethods}>
-            <form onSubmit={handleFormSubmit}>
-              <FormInputError isBlock>
-                <input
-                  className={styles.formElement}
-                  type="text"
-                  placeholder="E-mail"
-                  {...register('email', {
-                    required,
-                  })}
-                />
-              </FormInputError>
-              <FormInputError isBlock>
-                <TogglePasswordInput
-                  className={styles.formElement}
-                  placeholder="Heslo"
-                  {...register('password', { required })}
-                />
-              </FormInputError>
-              <Button primary className={styles.formElement} type="submit">
-                Přihlásit se
-              </Button>
-
-              <ButtonLink
-                tertiary
-                style={{ marginTop: '1.5rem' }}
+    <div className={styles.loginContainer}>
+      <div className={styles.formContainer}>
+        <header className={styles.title}>Přihlaste se ke svému účtu</header>
+        <p className={styles.subtitle}>
+          Zadejte své přihlašovací jméno a heslo <br />
+          pro přístup k aplikaci
+        </p>
+        {error && (
+          <div className={classNames(styles.error, styles.formElement)}>
+            {getErrorMessage(error)}
+          </div>
+        )}
+        <FormProvider {...formMethods}>
+          <form onSubmit={handleFormSubmit}>
+            <FormInputError isBlock>
+              <input
                 className={styles.formElement}
-                to="/send-reset-password-link"
-              >
-                přihlašuji se poprvé/zapomněl(a) jsem heslo
-              </ButtonLink>
-              <div className={styles.help}>
-                V případě problémů s přihlášením se obracej na{' '}
-                <a href="mailto:bis@brontosaurus.cz">bis@brontosaurus.cz</a>
-              </div>
-            </form>
-          </FormProvider>
-        </div>
+                type="text"
+                placeholder="E-mail"
+                {...register('email', {
+                  required,
+                })}
+              />
+            </FormInputError>
+            <FormInputError isBlock>
+              <TogglePasswordInput
+                className={styles.formElement}
+                placeholder="Heslo"
+                {...register('password', { required })}
+              />
+            </FormInputError>
+            <Button primary className={styles.formElement} type="submit">
+              Přihlásit se
+            </Button>
+
+            <ButtonLink
+              tertiary
+              style={{ marginTop: '1.5rem' }}
+              className={styles.formElement}
+              to="/send-reset-password-link"
+            >
+              přihlašuji se poprvé/zapomněl(a) jsem heslo
+            </ButtonLink>
+            <div className={styles.help}>
+              V případě problémů s přihlášením se obracej na{' '}
+              <a href="mailto:bis@brontosaurus.cz">bis@brontosaurus.cz</a>
+            </div>
+          </form>
+        </FormProvider>
       </div>
-    </>
+    </div>
   )
 }

--- a/src/pages/Logout.tsx
+++ b/src/pages/Logout.tsx
@@ -1,12 +1,17 @@
 import { useLogout } from 'hooks/useLogout'
 import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 export const Logout = () => {
+  const [searchParams] = useSearchParams()
   const logout = useLogout()
 
+  const next = searchParams.get('next') ?? undefined
+  const reload = typeof searchParams.get('reload') === 'string'
+
   useEffect(() => {
-    logout()
-  }, [logout])
+    logout(next, reload)
+  }, [logout, next, reload])
 
   return null
 }


### PR DESCRIPTION
Both pages have optional `next` and `reload` search parameters
- next: the page to redirect to after successful login or logout
- reload: if present, application will perform hard redirect, potentially leading outside the app

For example, one can go to `https://dev.bis.lomic.cz/logout?next=https%3A%2F%2Fexample.com%2F&reload` and it will redirect them to https://example.com. You can try out what happens if you don't provide `&reload` 😉 

Fixes #187 