### PR TITLE
Make fields in the contact-list table editable

### DIFF
--- a/cypress/e2e/closeEvent.cy.ts
+++ b/cypress/e2e/closeEvent.cy.ts
@@ -23,16 +23,18 @@ describe('Close event - evidence and participants', () => {
     )
   })
 
-  describe('import of simple participants list from xls', () => {
-    it('should load xls data to participants list form', () => {
-      cy.visit('/org/akce/1000/uzavrit')
+  describe('Simple participants list (contacts)', () => {
+    describe('Import of simple participants list from xls', () => {
+      it('should load xls data to participants list form', () => {
+        cy.visit('/org/akce/1000/uzavrit')
 
-      cy.get('label:contains(Mám jen jméno + příjmení + email)')
-        .should('be.visible')
-        .click()
-      cy.get('label:contains(Importovat seznam)')
-        .should('be.visible')
-        .selectFile('cypress/e2e/simple-participants.xlsx')
+        cy.get('label:contains(Mám jen jméno + příjmení + email)')
+          .should('be.visible')
+          .click()
+        cy.get('label:contains(Importovat seznam)')
+          .should('be.visible')
+          .selectFile('cypress/e2e/simple-participants.xlsx')
+      })
     })
   })
 

--- a/src/org/pages/CloseEvent/ParticipantsStep.tsx
+++ b/src/org/pages/CloseEvent/ParticipantsStep.tsx
@@ -64,7 +64,7 @@ export const ParticipantsStep = ({
   areParticipantsRequired: boolean
   methods: UseFormReturn<ParticipantsStepFormInnerShape>
 }) => {
-  const { watch, control, trigger, formState, setValue } = methods
+  const { watch, control, trigger, formState } = methods
 
   // list of participants is shown when it's required
   // or when organizers prefer it rather than filling just numbers
@@ -89,7 +89,7 @@ export const ParticipantsStep = ({
       */}
         <FormSectionGroup>
           {!areParticipantsRequired && (
-            <FormSection required header="Zpusob registrace ucastniku">
+            <FormSection required header="Způsob registrace účastníků">
               <FormInputError name="participantInputType">
                 <Controller
                   name="record.participantInputType"
@@ -175,12 +175,12 @@ export const ParticipantsStep = ({
             )}
 
           {!areParticipantsRequired && inputType === 'simple-list' && (
-            <FormSection required header="Seznam ucastniku">
+            <FormSection required header="Seznam účastníků">
               <SimpleParticipants />
             </FormSection>
           )}
           {(areParticipantsRequired || inputType === 'full-list') && (
-            <FormSection required header="Seznam ucastniku">
+            <FormSection required header="Seznam účastníků">
               <ParticipantsList eventId={event.id} eventName={event.name} />
             </FormSection>
           )}

--- a/src/org/pages/CloseEvent/SimpleParticipants.module.scss
+++ b/src/org/pages/CloseEvent/SimpleParticipants.module.scss
@@ -35,16 +35,28 @@
     &:hover {
       overflow: visible;
     }
+
+    &:last-child {
+      width: 80px !important;
+      button {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
   }
 
   td {
+    padding: 0;
+    height: 48px;
     position: relative;
-    &:last-child {
-      width: 10px;
-    }
 
     &.error {
-      box-shadow: inset 0px 0px 0px 2px colors.$error;
+      input {
+        border-color: colors.$error !important;
+      }
     }
     .errorMessage {
       padding-left: 0.25rem;
@@ -58,6 +70,19 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+
+    input {
+      border: 2px solid #0000;
+      background: none;
+      border-radius: 0;
+      width: 100%;
+      height: 100%;
+      padding: 8px;
+
+      &:focus {
+        border-color: colors.$bronto-light;
+      }
+    }
   }
 }
 
@@ -66,8 +91,7 @@
   padding: 10px 0;
 }
 
-
-.userAndExportLine{
+.userAndExportLine {
   display: flex;
   justify-content: space-between;
 }

--- a/src/org/pages/CloseEvent/SimpleParticipants.tsx
+++ b/src/org/pages/CloseEvent/SimpleParticipants.tsx
@@ -8,16 +8,10 @@ import {
   FormInputError,
   ImportExcelButton,
   InlineSection,
-  StyledModal,
 } from 'components'
 import { get } from 'lodash'
 import tableStyles from 'org/components/EventForm/steps/ParticipantsStep.module.scss'
-import {
-  FormHTMLAttributes,
-  TdHTMLAttributes,
-  useEffect,
-  useState,
-} from 'react'
+import { FormHTMLAttributes, TdHTMLAttributes, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import {
   FieldErrors,
@@ -28,7 +22,7 @@ import {
   useForm,
   useFormContext,
 } from 'react-hook-form'
-import { FaCheck, FaPencilAlt, FaTrash } from 'react-icons/fa'
+import { FaCheck, FaTrash } from 'react-icons/fa'
 import * as validationMessages from 'utils/validationMessages'
 import type { ParticipantsStepFormShape } from './CloseEventForm'
 import styles from './SimpleParticipants.module.scss'
@@ -49,73 +43,14 @@ export const SimpleParticipants = () => {
   } = useFormContext<ParticipantsStepFormShape>()
   const peopleFields = useFieldArray({ control, name: 'record.contacts' })
 
-  const [open, setOpen] = useState(false)
-  const [defaultValues, setDefaultValues] = useState<EventContact>()
-  const [editPromise, setEditPromise] = useState<{
-    resolve: (data: EventContact) => void
-    reject: (reason?: any) => void
-    promise: Promise<EventContact>
-  }>()
-
-  const getModalData = () => {
-    let res = undefined
-    let rej = undefined
-
-    const promise = new Promise<EventContact>((resolve, reject) => {
-      res = resolve
-      rej = reject
-    })
-
-    const p = {
-      promise,
-      resolve: res as any,
-      reject: rej as any,
-    }
-
-    setEditPromise(p)
-
-    return promise
-  }
-
-  // register array of contacts
-  useEffect(() => {
-    register('record.contacts')
-  }, [register])
-
   useEffect(() => {
     if (isSubmitted) trigger('record.contacts')
   }, [isSubmitted, trigger, peopleFields.fields])
 
-  const handleEdit = async (data: EventContact, i: number) => {
-    setOpen(true)
-    setDefaultValues(data)
-    const finalData = await getModalData()
-    peopleFields.update(i, finalData)
-  }
-
-  const handleFinishEdit = (data: EventContact) => {
-    if (editPromise?.resolve) editPromise.resolve(data)
-  }
-
   return (
     <div className={styles.container}>
-      <StyledModal
-        title="Upravit účastníka"
-        open={open}
-        onClose={() => setOpen(false)}
-      >
-        <SimpleParticipantInput
-          formId="edit-participant-input"
-          defaultValues={defaultValues}
-          onSubmit={data => {
-            handleFinishEdit(data)
-            setOpen(false)
-          }}
-        />
-      </StyledModal>
-
       <div className={classNames(styles.header, styles.userAndExportLine)}>
-        Novy ucastnik:{' '}
+        Nový účastník:{' '}
         <div className={styles.inportPart}>
           <ImportExcelButton<EventContact>
             keyMap={importMap}
@@ -140,7 +75,6 @@ export const SimpleParticipants = () => {
             <th>E-mail</th>
             <th>Telefon</th>
             <th></th>
-            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -152,26 +86,21 @@ export const SimpleParticipants = () => {
               }, ${item.phone || '—'}`}
             >
               <TdErr name={`record.contacts.${i}.first_name`} errors={errors}>
-                {item.first_name}
+                <input {...register(`record.contacts.${i}.first_name`)} />
               </TdErr>
               <TdErr name={`record.contacts.${i}.last_name`} errors={errors}>
-                {item.last_name}
+                <input {...register(`record.contacts.${i}.last_name`)} />
               </TdErr>
               <TdErr name={`record.contacts.${i}.email`} errors={errors}>
-                {item.email}
+                <input {...register(`record.contacts.${i}.email`)} />
               </TdErr>
               <TdErr name={`record.contacts.${i}.phone`} errors={errors}>
-                {item.phone}
+                <input {...register(`record.contacts.${i}.phone`)} />
               </TdErr>
               <td>
-                <Button type="button" onClick={() => handleEdit(item, i)}>
-                  <FaPencilAlt />
-                </Button>
-              </td>
-              <td>
-                <Button type="button" onClick={() => peopleFields.remove(i)}>
+                <button type="button" onClick={() => peopleFields.remove(i)}>
                   <FaTrash />
-                </Button>
+                </button>
               </td>
             </tr>
           ))}

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -24,7 +24,7 @@ select {
 }
 
 input[type='number'] {
-  -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 // button,


### PR DESCRIPTION
Fixes #191

As follow-up we could consider filling new contact directly in the table, we would only need a way to add a new row (at the beginning or at the end), e.g. a button above delete buttons