### PR TITLE
Add confirmation modal component and use it to confirm registration change

### DIFF
--- a/src/hooks/useConfirmWithModal.tsx
+++ b/src/hooks/useConfirmWithModal.tsx
@@ -1,0 +1,92 @@
+import { Actions, Button } from 'components'
+import modalStyles from 'components/StyledModal/StyledModal.module.scss'
+import {
+  useShowApiErrorMessage,
+  useShowMessage,
+} from 'features/systemMessage/useSystemMessage'
+import { confirmAlert } from 'react-confirm-alert'
+import 'react-confirm-alert/src/react-confirm-alert.css'
+
+/**
+ * A custom hook that shows a confirmation modal before executing a function.
+ *
+ * @param successMessage - Optional success message to show upon successful completion of the function.
+ * @param errorMessage - Optional error message to show upon unsuccessful completion of the function.
+ * @param title - The title of the confirmation modal.
+ * @param message - The message to show in the confirmation modal.
+ * @returns the confirmWithModal function
+ */
+export const useConfirmWithModal = ({
+  successMessage,
+  errorMessage,
+  title,
+  message,
+}: {
+  successMessage?: string
+  errorMessage?: string
+  title: string
+  message: string
+}) => {
+  // Custom hook to show API error messages
+  useShowApiErrorMessage(
+    undefined,
+    errorMessage || 'Nepodařilo se vykonat akci',
+  )
+  // Custom hook to show general messages
+  const showMessage = useShowMessage()
+
+  /**
+   * Shows a confirmation modal before executing the given function.
+   *
+   * @param onConfirm - The function to execute if the user confirms the action.
+   */
+  const confirmWithModal = async (onConfirm: Function) => {
+    // Show confirmation modal and wait for user input
+    const isConfirmed = await new Promise(resolve => {
+      confirmAlert({
+        customUI: ({ title, message, onClose }) => (
+          <div className={modalStyles.modal}>
+            <div className={modalStyles.content}>
+              <header className={modalStyles.modalTitleBox}>{title}</header>
+              <div className={modalStyles.modalFormBox}>
+                <div className={modalStyles.infoBox}>{message}</div>
+                <Actions>
+                  <Button
+                    secondary
+                    onClick={() => {
+                      resolve(false)
+                      onClose()
+                    }}
+                  >
+                    Zruš
+                  </Button>
+                  <Button
+                    danger
+                    onClick={() => {
+                      resolve(true)
+                      onClose()
+                    }}
+                  >
+                    Pokračuj
+                  </Button>
+                </Actions>
+              </div>
+            </div>
+          </div>
+        ),
+        title,
+        message,
+      })
+    })
+    // If the user confirmed the action, execute the provided function and show the success message (if provided)
+    if (isConfirmed) {
+      await onConfirm()
+      successMessage &&
+        showMessage({
+          message: successMessage,
+          type: 'success',
+        })
+    }
+  }
+  return [confirmWithModal] as const
+}

--- a/src/org/pages/CloseEvent/ParticipantsStep.tsx
+++ b/src/org/pages/CloseEvent/ParticipantsStep.tsx
@@ -13,6 +13,7 @@ import {
   NumberInput,
 } from 'components'
 import { InlineSection } from 'components/FormLayout/FormLayout'
+import { useConfirmWithModal } from 'hooks/useConfirmWithModal'
 import { ParticipantsStep as ParticipantsList } from 'org/components/EventForm/steps/ParticipantsStep'
 import { useEffect } from 'react'
 import { Controller, FormProvider, UseFormReturn } from 'react-hook-form'
@@ -81,6 +82,12 @@ export const ParticipantsStep = ({
     return () => subscription.unsubscribe()
   }, [formState.isSubmitted, trigger, watch])
 
+  const [confirmWithModal] = useConfirmWithModal({
+    title: 'Měníš způsob registrace účastníků',
+    message:
+      'Je možné vybrat pouze jeden způsob registrace. Pokud chceš změnit způsob registrace, data, která jsou zadaná v počtu účastníků a seznamu účastníků, nebudou uložena. Chceš pokračovat?',
+  })
+
   return (
     <FormProvider {...methods}>
       <form>
@@ -93,7 +100,7 @@ export const ParticipantsStep = ({
               <FormInputError name="participantInputType">
                 <Controller
                   name="record.participantInputType"
-                  control={methods.control}
+                  control={control}
                   rules={{ required }}
                   render={({ field }) => (
                     <IconSelectGroup>
@@ -111,7 +118,13 @@ export const ParticipantsStep = ({
                               value={id}
                               checked={id === field.value}
                               onChange={e => {
-                                field.onChange(e.target.value)
+                                if (inputType) {
+                                  confirmWithModal(() =>
+                                    field.onChange(e.target.value),
+                                  )
+                                } else {
+                                  field.onChange(e.target.value)
+                                }
                               }}
                             />
                           )


### PR DESCRIPTION

This commit introduces a confirmation modal component and uses it to confirm changes in the registration process. Specifically, when changing the registration method for participants, a modal pops up to confirm the change and notify the user that any unsaved data will be lost. This provides a better user experience and prevents accidental loss of data.

Changes made in this commit include adding the new modal component, importing it where necessary, and updating the relevant code to use it. The changes have been thoroughly tested and are ready for deployment.

![image](https://user-images.githubusercontent.com/63733780/220351216-cc1e73c5-aaeb-499e-bdf7-ca9180d2f2c2.png)
