### PR TITLE
Fix bug: Allow non-numeric coordinates in standard format

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "classnames": "^2.3.2",
     "dayjs": "^1.11.6",
     "dompurify": "^2.4.1",
+    "geolib": "^3.3.3",
     "gh-pages": "^5.0.0",
     "jspdf": "^2.5.1",
     "leaflet": "^1.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5400,6 +5400,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+geolib@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-3.3.3.tgz#17f5a0dcdc0b051bd631b66f7131d2c14c54a15b"
+  integrity sha512-YO704pzdB/8QQekQuDmFD5uv5RAwAf4rOUPdcMhdEOz+HoPWD0sC7Qqdwb+LAvwIjXVRawx0QgZlocKYh8PFOQ==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
Allow coordinates in format 49°12′18.94″. Before, the application crashed.