### PR TITLE
Fix missing crypto.randomUUID() in older browsers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,8 +16,8 @@ To run tests interactively,
    If other app is running on port 3000, you'll have to stop it first
 1. `yarn cypress open`
 1. Select e2e tests from the available options
-1. Select Chrome/Chromium for browser
-   Firefox doesn't currently work for testing because some crypto methods are disabled in cypress
+1. Select your preferred browser
+1. Select a test file to run from list
 
 ### Automatic
 

--- a/src/features/systemMessage/useSystemMessage.ts
+++ b/src/features/systemMessage/useSystemMessage.ts
@@ -22,7 +22,8 @@ export const useShowMessage = () => {
     (
       message: Pick<SystemMessage, 'type' | 'message' | 'detail' | 'timeout'>,
     ) => {
-      const id = globalThis.crypto.randomUUID()
+      // use Math.random for backward compatibility, e.g. Firefox older than v95
+      const id = globalThis.crypto?.randomUUID?.() ?? Math.random().toString()
 
       const msg = { ...message, id, time: Date.now() }
       dispatch(actions.addMessage(msg))


### PR DESCRIPTION
Error from Sentry
crypto.randomUUID is supported since Firefox v95
https://caniuse.com/mdn-api_crypto_randomuuid

This has additional benefit that tests can run in Firefox now