### PR TITLE
Fix: Add polyfills to support older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "leaflet": "^1.9.2",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
+    "react-app-polyfill": "^3.0.0",
     "react-confirm-alert": "^3.0.6",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.35.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,8 @@
+// polyfills must be imported first
+// https://github.com/facebook/create-react-app/blob/main/packages/react-app-polyfill/README.md#polyfilling-other-language-features
+import 'react-app-polyfill/ie11'
+import 'react-app-polyfill/stable'
+// this line intentionally left blank
 import './config'
 import './index.scss'
 // this line intentionally left blank


### PR DESCRIPTION
https://create-react-app.dev/docs/supported-browsers-features/#supported-browsers

This will add 130kB to the production build, which is somewhat significant. But it should help support older browsers which fail regularly, according to Sentry.