### PR TITLE
Fix error on participants without address

### DIFF
--- a/src/org/components/EventForm/steps/registration/Participants.tsx
+++ b/src/org/components/EventForm/steps/registration/Participants.tsx
@@ -356,7 +356,7 @@ export const Participants: FC<{
                     </td>
                     <td>{participant.last_name}</td>
                     <td>{formatDateTime(participant.birthday)}</td>
-                    <td>{formatAddress(participant.address)}</td>
+                    <td>{participant.address && formatAddress(participant.address)}</td>
                     <td>{participant.phone}</td>
                     <td>{participant.email}</td>
                     <TableCellIconButton


### PR DESCRIPTION
Displaying the table of participants crashed when the address of any participant was null. This is now fixed.